### PR TITLE
Small fix on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The modules/zip files is in the the `dist` folder of the repository. Add it to y
 Require the modules with the following code:
 
 ~~~
-var Dialogs = require(yy.tidialogs);
+var Dialogs = require("yy.tidialogs");
 ~~~
 
 


### PR DESCRIPTION
Fix on require function argument. You pass a string, not the module itself.
