### PR TITLE
Fix broken Markdown headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ picker.show();
 * Compatible Ti.UI.Picker.showTimePickerDialog and Ti.UI.Picker.showDatePickerDialog properties.
 
 
-###Licence: MIT
+### Licence: MIT


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.
            
See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.
            
Tackles bryant1410/readmesfix#1