### PR TITLE
Formatting. Base classes. Missing properties.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,26 @@
+---
+Language: Java
+AccessModifierOffset: -4
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+# class, constructor, method should be next line
+BreakBeforeBraces: Linux
+# Keep '=' at end of line when wrapping, but move things like '&&', '||' to beginning of newline
+BreakBeforeBinaryOperators: NonAssignment
+# FIXME: break for brace after synchronized block, anonymous class declarations
+BreakAfterJavaFieldAnnotations: true
+ColumnLimit: 120
+IndentCaseLabels: true
+IndentWidth: 4
+MaxEmptyLinesToKeep: 1
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpacesInParentheses: false
+TabWidth: 4
+UseTab: ForContinuationAndIndentation
+SpaceAfterCStyleCast: true
+# Spaces inside {} for array literals, i.e. "new Object[] { args }"
+Cpp11BracedListStyle: false
+ReflowComments: false

--- a/src/yy/tidialogs/BaseDialogProxy.java
+++ b/src/yy/tidialogs/BaseDialogProxy.java
@@ -1,0 +1,36 @@
+package yy.tidialogs;
+
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.util.TiUIHelper;
+
+@Kroll.proxy
+public abstract class BaseDialogProxy extends TiViewProxy
+{
+
+	public BaseDialogProxy()
+	{
+		super();
+	}
+
+	@Override
+	protected void handleShow(KrollDict options)
+	{
+		super.handleShow(options);
+		// If there's a lock on the UI message queue, there's a good chance
+		// we're in the middle of activity stack transitions. An alert
+		// dialog should occur above the "topmost" activity, so if activity
+		// stack transitions are occurring, try to give them a chance to
+		// "settle"
+		// before determining which Activity should be the context for the
+		// AlertDialog.
+		TiUIHelper.runUiDelayedIfBlock(new Runnable() {
+			@Override
+			public void run()
+			{
+				getOrCreateView().show();
+			}
+		});
+	}
+}

--- a/src/yy/tidialogs/BaseUIDialog.java
+++ b/src/yy/tidialogs/BaseUIDialog.java
@@ -1,0 +1,41 @@
+package yy.tidialogs;
+
+import android.app.AlertDialog;
+
+import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.view.TiUIView;
+
+public abstract class BaseUIDialog extends TiUIView
+{
+	protected AlertDialog dialog;
+
+	public BaseUIDialog(TiViewProxy proxy)
+	{
+		super(proxy);
+	}
+
+	abstract protected AlertDialog getDialog();
+
+	@Override
+	public void show()
+	{
+		getDialog().show();
+	}
+
+	@Override
+	public void hide()
+	{
+		if (dialog != null) {
+			dialog.hide();
+		}
+	}
+
+	@Override
+	public void release()
+	{
+		if (dialog != null) {
+			dialog.dismiss();
+			dialog = null;
+		}
+	}
+}

--- a/src/yy/tidialogs/BaseUIDialog.java
+++ b/src/yy/tidialogs/BaseUIDialog.java
@@ -2,16 +2,38 @@ package yy.tidialogs;
 
 import android.app.AlertDialog;
 
+import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.view.TiUIView;
+
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class BaseUIDialog extends TiUIView
 {
 	protected AlertDialog dialog;
 
+	private AtomicInteger dismissCallCount = new AtomicInteger(0);
+	protected OnDismissListener dismissListener;
+
 	public BaseUIDialog(TiViewProxy proxy)
 	{
 		super(proxy);
+		dismissListener = new OnDismissListener() {
+			@Override
+			public void onDismiss(DialogInterface dialog)
+			{
+				if (dismissCallCount.get() == 0) {
+					dismissCallCount.incrementAndGet();
+					KrollDict data = new KrollDict();
+					data.put("cancel", true);
+					data.put("value", null);
+					fireEvent("cancel", data);
+				}
+			}
+		};
 	}
 
 	abstract protected AlertDialog getDialog();

--- a/src/yy/tidialogs/DatePickerProxy.java
+++ b/src/yy/tidialogs/DatePickerProxy.java
@@ -16,8 +16,10 @@ import android.content.DialogInterface;
 import android.widget.DatePicker;
 
 @Kroll.proxy(creatableInModule = TidialogsModule.class)
-public class DatePickerProxy extends TiViewProxy {
-	private class BasicDatePicker extends TiUIView {
+public class DatePickerProxy extends TiViewProxy
+{
+	private class BasicDatePicker extends TiUIView
+	{
 
 		private int year;
 		private int month;
@@ -26,57 +28,57 @@ public class DatePickerProxy extends TiViewProxy {
 		private String okButtonTitle;
 		private String cancelButtonTitle;
 
-		public BasicDatePicker(TiViewProxy proxy) {
+		public BasicDatePicker(TiViewProxy proxy)
+		{
 			super(proxy);
-
 		}
 
-		private DatePickerDialog getDialog() {
-			DatePickerDialog picker = new DatePickerDialog(this.proxy.getActivity(),
-						new DatePickerDialog.OnDateSetListener() {
-							// when dialog box is closed, below method will be
-							// called.
-							public void onDateSet(DatePicker view,
-									int selectedYear, int selectedMonth,
-									int selectedDay) {
-								year = selectedYear;
-								month = selectedMonth;
-								day = selectedDay;
+		private DatePickerDialog getDialog()
+		{
+			DatePickerDialog picker =
+				new DatePickerDialog(this.proxy.getActivity(), new DatePickerDialog.OnDateSetListener() {
+					// when dialog box is closed, below method will be
+					// called.
+					public void onDateSet(DatePicker view, int selectedYear, int selectedMonth, int selectedDay)
+					{
+						year = selectedYear;
+						month = selectedMonth;
+						day = selectedDay;
 
-								KrollDict data = new KrollDict();
+						KrollDict data = new KrollDict();
 
-									Calendar calendar = Calendar.getInstance();
-									calendar.set(Calendar.YEAR, year);
-									calendar.set(Calendar.MONTH, month);
-									calendar.set(Calendar.DAY_OF_MONTH, day);
-									Date value = calendar.getTime();
+						Calendar calendar = Calendar.getInstance();
+						calendar.set(Calendar.YEAR, year);
+						calendar.set(Calendar.MONTH, month);
+						calendar.set(Calendar.DAY_OF_MONTH, day);
+						Date value = calendar.getTime();
 
-									data.put("value", value);
-									data.put("year", year);
-									data.put("month", month);
-									data.put("day", day);
-                                    fireEvent("click", data);		
-
-							}
-						}, year, month, day);
+						data.put("value", value);
+						data.put("year", year);
+						data.put("month", month);
+						data.put("day", day);
+						fireEvent("click", data);
+					}
+				}, year, month, day);
 			picker.setCanceledOnTouchOutside(false);
 
 			picker.setButton(DialogInterface.BUTTON_POSITIVE, okButtonTitle, picker);
 
-			picker.setButton(DialogInterface.BUTTON_NEGATIVE, cancelButtonTitle,
-				new DialogInterface.OnClickListener() {
+			picker.setButton(DialogInterface.BUTTON_NEGATIVE, cancelButtonTitle, new DialogInterface.OnClickListener() {
 
-					@Override
-					public void onClick(DialogInterface dialog, int which) {
-						fireEvent("cancel", new KrollDict());
-					}
-				});
+				@Override
+				public void onClick(DialogInterface dialog, int which)
+				{
+					fireEvent("cancel", new KrollDict());
+				}
+			});
 
 			return picker;
 		}
 
 		@Override
-		public void processProperties(KrollDict d) {
+		public void processProperties(KrollDict d)
+		{
 			super.processProperties(d);
 			Calendar c = Calendar.getInstance();
 			if (d.containsKey("value")) {
@@ -105,7 +107,7 @@ public class DatePickerProxy extends TiViewProxy {
 			if (d.containsKey("okButtonTitle")) {
 				okButtonTitle = d.getString("okButtonTitle");
 			} else {
-				okButtonTitle =  this.proxy.getActivity().getApplication().getResources().getString(R.string.ok);
+				okButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.ok);
 			}
 			if (d.containsKey("cancelButtonTitle")) {
 				cancelButtonTitle = d.getString("cancelButtonTitle");
@@ -114,32 +116,37 @@ public class DatePickerProxy extends TiViewProxy {
 			}
 		}
 
-		public void show() {
+		public void show()
+		{
 			getDialog().show();
 		}
-
 	}
 
-	public DatePickerProxy() {
+	public DatePickerProxy()
+	{
 		super();
 	}
 
 	@Override
-	public TiUIView createView(Activity activity) {
+	public TiUIView createView(Activity activity)
+	{
 		return new BasicDatePicker(this);
 	}
 
 	@Override
-	public void handleCreationDict(KrollDict options) {
+	public void handleCreationDict(KrollDict options)
+	{
 		super.handleCreationDict(options);
 	}
 
 	@Override
-	protected void handleShow(KrollDict options) {
+	protected void handleShow(KrollDict options)
+	{
 		super.handleShow(options);
 		TiUIHelper.runUiDelayedIfBlock(new Runnable() {
 			@Override
-			public void run() {
+			public void run()
+			{
 				BasicDatePicker d = (BasicDatePicker) getOrCreateView();
 				d.show();
 			}

--- a/src/yy/tidialogs/DatePickerProxy.java
+++ b/src/yy/tidialogs/DatePickerProxy.java
@@ -74,7 +74,8 @@ public class DatePickerProxy extends BaseDialogProxy
 
 			if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 				&& (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)) {
-				picker = new TiDatePickerDialog(proxy.getActivity(), dateSetListener, year, month, day);
+				picker =
+					new TiDatePickerDialog(TiApplication.getAppCurrentActivity(), dateSetListener, year, month, day);
 			} else {
 				picker = new DatePickerDialog(TiApplication.getAppCurrentActivity(), dateSetListener, year, month, day);
 			}
@@ -135,12 +136,14 @@ public class DatePickerProxy extends BaseDialogProxy
 			if (d.containsKey("okButtonTitle")) {
 				okButtonTitle = d.getString("okButtonTitle");
 			} else {
-				okButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.ok);
+				okButtonTitle =
+					TiApplication.getAppCurrentActivity().getApplication().getResources().getString(R.string.ok);
 			}
 			if (d.containsKey("cancelButtonTitle")) {
 				cancelButtonTitle = d.getString("cancelButtonTitle");
 			} else {
-				cancelButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.cancel);
+				cancelButtonTitle =
+					TiApplication.getAppCurrentActivity().getApplication().getResources().getString(R.string.cancel);
 			}
 		}
 	}

--- a/src/yy/tidialogs/DatePickerProxy.java
+++ b/src/yy/tidialogs/DatePickerProxy.java
@@ -43,6 +43,9 @@ public class DatePickerProxy extends BaseDialogProxy
 
 		protected DatePickerDialog getDialog()
 		{
+			if (dialog != null) {
+				return (DatePickerDialog) dialog;
+			}
 			OnDateSetListener dateSetListener = new OnDateSetListener() {
 				// when dialog box is closed, below method will be
 				// called.

--- a/src/yy/tidialogs/DatePickerProxy.java
+++ b/src/yy/tidialogs/DatePickerProxy.java
@@ -84,18 +84,11 @@ public class DatePickerProxy extends BaseDialogProxy
 				picker.getDatePicker().setMaxDate(trimDate(maxDate).getTime());
 			}
 
+			picker.setOnDismissListener(dismissListener);
+
 			picker.setCanceledOnTouchOutside(false);
 
 			picker.setButton(DialogInterface.BUTTON_POSITIVE, okButtonTitle, picker);
-
-			picker.setButton(DialogInterface.BUTTON_NEGATIVE, cancelButtonTitle, new DialogInterface.OnClickListener() {
-
-				@Override
-				public void onClick(DialogInterface dialog, int which)
-				{
-					fireEvent("cancel", new KrollDict());
-				}
-			});
 
 			dialog = picker;
 			return picker;

--- a/src/yy/tidialogs/DatePickerProxy.java
+++ b/src/yy/tidialogs/DatePickerProxy.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.proxy.TiViewProxy;
-import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
 import android.R;
@@ -16,9 +15,9 @@ import android.content.DialogInterface;
 import android.widget.DatePicker;
 
 @Kroll.proxy(creatableInModule = TidialogsModule.class)
-public class DatePickerProxy extends TiViewProxy
+public class DatePickerProxy extends BaseDialogProxy
 {
-	private class BasicDatePicker extends TiUIView
+	private class BasicDatePicker extends BaseUIDialog
 	{
 
 		private int year;
@@ -33,7 +32,7 @@ public class DatePickerProxy extends TiViewProxy
 			super(proxy);
 		}
 
-		private DatePickerDialog getDialog()
+		protected DatePickerDialog getDialog()
 		{
 			DatePickerDialog picker =
 				new DatePickerDialog(this.proxy.getActivity(), new DatePickerDialog.OnDateSetListener() {
@@ -73,6 +72,7 @@ public class DatePickerProxy extends TiViewProxy
 				}
 			});
 
+			dialog = picker;
 			return picker;
 		}
 
@@ -115,11 +115,6 @@ public class DatePickerProxy extends TiViewProxy
 				cancelButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.cancel);
 			}
 		}
-
-		public void show()
-		{
-			getDialog().show();
-		}
 	}
 
 	public DatePickerProxy()
@@ -137,19 +132,5 @@ public class DatePickerProxy extends TiViewProxy
 	public void handleCreationDict(KrollDict options)
 	{
 		super.handleCreationDict(options);
-	}
-
-	@Override
-	protected void handleShow(KrollDict options)
-	{
-		super.handleShow(options);
-		TiUIHelper.runUiDelayedIfBlock(new Runnable() {
-			@Override
-			public void run()
-			{
-				BasicDatePicker d = (BasicDatePicker) getOrCreateView();
-				d.show();
-			}
-		});
 	}
 }

--- a/src/yy/tidialogs/MultiPickerProxy.java
+++ b/src/yy/tidialogs/MultiPickerProxy.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -51,7 +52,7 @@ public class MultiPickerProxy extends BaseDialogProxy
 		private Builder getBuilder()
 		{
 			if (builder == null) {
-				builder = new AlertDialog.Builder(this.proxy.getActivity());
+				builder = new AlertDialog.Builder(TiApplication.getAppCurrentActivity());
 				builder.setCancelable(true);
 			}
 			return builder;
@@ -91,13 +92,15 @@ public class MultiPickerProxy extends BaseDialogProxy
 			if (properties.containsKey("okButtonTitle")) {
 				okButtonTitle = properties.getString("okButtonTitle");
 			} else {
-				okButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.ok);
+				okButtonTitle =
+					TiApplication.getAppCurrentActivity().getApplication().getResources().getString(R.string.ok);
 			}
 
 			if (properties.containsKeyAndNotNull("cancelButtonTitle")) {
 				cancelButtonTitle = properties.getString("cancelButtonTitle");
 			} else {
-				cancelButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.cancel);
+				cancelButtonTitle =
+					TiApplication.getAppCurrentActivity().getApplication().getResources().getString(R.string.cancel);
 			}
 
 			if (properties.containsKeyAndNotNull("canCancel")) {

--- a/src/yy/tidialogs/MultiPickerProxy.java
+++ b/src/yy/tidialogs/MultiPickerProxy.java
@@ -40,6 +40,7 @@ public class MultiPickerProxy extends BaseDialogProxy
 		protected AlertDialog getDialog()
 		{
 			dialog = getBuilder().create();
+			dialog.setOnDismissListener(dismissListener);
 			builder = null;
 			return dialog;
 		}
@@ -177,19 +178,7 @@ public class MultiPickerProxy extends BaseDialogProxy
 						}
 					});
 
-				if (cancellable == true) {
-
-					// cancel returns nothing
-					getBuilder().setNegativeButton(cancelButtonTitle, new DialogInterface.OnClickListener() {
-						@Override
-						public void onClick(DialogInterface dialog, int id)
-						{
-							fireEvent("cancel", new KrollDict());
-						}
-					});
-				} else {
-					getBuilder().setCancelable(false);
-				}
+				getBuilder().setCancelable(cancellable);
 			}
 		}
 	}

--- a/src/yy/tidialogs/MultiPickerProxy.java
+++ b/src/yy/tidialogs/MultiPickerProxy.java
@@ -8,13 +8,9 @@ import java.util.List;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
-import org.appcelerator.titanium.io.TiBaseFile;
-import org.appcelerator.titanium.io.TiFileFactory;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiUIHelper;
-import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiUIView;
 import org.appcelerator.kroll.common.Log;
 
@@ -23,22 +19,29 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
 import android.content.DialogInterface;
-import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 
 @Kroll.proxy(creatableInModule = TidialogsModule.class)
-public class MultiPickerProxy extends TiViewProxy
+public class MultiPickerProxy extends BaseDialogProxy
 {
 	private static final String LCAT = "TiDialogs";
 	private KrollFunction onChange;
 
-	private class MultiPicker extends TiUIView
+	private class MultiPicker extends BaseUIDialog
 	{
 		Builder builder;
 
 		public MultiPicker(TiViewProxy proxy)
 		{
 			super(proxy);
+		}
+
+		@Override
+		protected AlertDialog getDialog()
+		{
+			dialog = getBuilder().create();
+			builder = null;
+			return dialog;
 		}
 
 		private Builder getBuilder()
@@ -189,13 +192,6 @@ public class MultiPickerProxy extends TiViewProxy
 				}
 			}
 		}
-
-		public void show()
-		{
-			getBuilder().create().show();
-			builder = null;
-			Log.d(LCAT, "show Dialog");
-		}
 	}
 
 	public MultiPickerProxy()
@@ -213,26 +209,5 @@ public class MultiPickerProxy extends TiViewProxy
 	public void handleCreationDict(KrollDict options)
 	{
 		super.handleCreationDict(options);
-	}
-
-	@Override
-	protected void handleShow(KrollDict options)
-	{
-		super.handleShow(options);
-		// If there's a lock on the UI message queue, there's a good chance
-		// we're in the middle of activity stack transitions. An alert
-		// dialog should occur above the "topmost" activity, so if activity
-		// stack transitions are occurring, try to give them a chance to
-		// "settle"
-		// before determining which Activity should be the context for the
-		// AlertDialog.
-		TiUIHelper.runUiDelayedIfBlock(new Runnable() {
-			@Override
-			public void run()
-			{
-				MultiPicker d = (MultiPicker) getOrCreateView();
-				d.show();
-			}
-		});
 	}
 }

--- a/src/yy/tidialogs/MultiPickerProxy.java
+++ b/src/yy/tidialogs/MultiPickerProxy.java
@@ -39,6 +39,9 @@ public class MultiPickerProxy extends BaseDialogProxy
 		@Override
 		protected AlertDialog getDialog()
 		{
+			if (dialog != null) {
+				return dialog;
+			}
 			dialog = getBuilder().create();
 			dialog.setOnDismissListener(dismissListener);
 			builder = null;

--- a/src/yy/tidialogs/MultiPickerProxy.java
+++ b/src/yy/tidialogs/MultiPickerProxy.java
@@ -18,7 +18,6 @@ import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiUIView;
 import org.appcelerator.kroll.common.Log;
 
-
 import android.R;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -27,21 +26,23 @@ import android.content.DialogInterface;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 
-
-
 @Kroll.proxy(creatableInModule = TidialogsModule.class)
-public class MultiPickerProxy extends TiViewProxy {
+public class MultiPickerProxy extends TiViewProxy
+{
 	private static final String LCAT = "TiDialogs";
 	private KrollFunction onChange;
 
-	private class MultiPicker extends TiUIView {
+	private class MultiPicker extends TiUIView
+	{
 		Builder builder;
 
-		public MultiPicker(TiViewProxy proxy) {
+		public MultiPicker(TiViewProxy proxy)
+		{
 			super(proxy);
 		}
 
-		private Builder getBuilder() {
+		private Builder getBuilder()
+		{
 			if (builder == null) {
 				builder = new AlertDialog.Builder(this.proxy.getActivity());
 				builder.setCancelable(true);
@@ -50,7 +51,8 @@ public class MultiPickerProxy extends TiViewProxy {
 		}
 
 		@Override
-		public void processProperties(KrollDict properties) {
+		public void processProperties(KrollDict properties)
+		{
 			super.processProperties(properties);
 			String okButtonTitle;
 			String cancelButtonTitle;
@@ -69,29 +71,26 @@ public class MultiPickerProxy extends TiViewProxy {
 				getBuilder().setMessage(properties.getString("message"));
 			}
 			if (properties.containsKeyAndNotNull("icon")) {
-				Drawable icon = TiUIHelper.getResourceDrawable(resolveUrl(null,
-						properties.getString("icon")));
+				Drawable icon = TiUIHelper.getResourceDrawable(resolveUrl(null, properties.getString("icon")));
 				getBuilder().setIcon(icon);
 			}
 			if (properties.containsKeyAndNotNull(TiC.PROPERTY_ANDROID_VIEW)) {
 				Object o = properties.get(TiC.PROPERTY_ANDROID_VIEW);
 				if (o instanceof TiUIView) {
-					 TiUIView view = (TiUIView)o; 
+					TiUIView view = (TiUIView) o;
 					getBuilder().setCustomTitle(view.getNativeView());
 				}
 			}
 			if (properties.containsKey("okButtonTitle")) {
 				okButtonTitle = properties.getString("okButtonTitle");
 			} else {
-				okButtonTitle = this.proxy.getActivity().getApplication()
-						.getResources().getString(R.string.ok);
+				okButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.ok);
 			}
 
 			if (properties.containsKeyAndNotNull("cancelButtonTitle")) {
 				cancelButtonTitle = properties.getString("cancelButtonTitle");
 			} else {
-				cancelButtonTitle = this.proxy.getActivity().getApplication()
-						.getResources().getString(R.string.cancel);
+				cancelButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.cancel);
 			}
 
 			if (properties.containsKeyAndNotNull("canCancel")) {
@@ -113,117 +112,112 @@ public class MultiPickerProxy extends TiViewProxy {
 
 				// are there any preselections?
 				if (properties.containsKeyAndNotNull("selected")) {
-					List<String> s = Arrays.asList(properties
-							.getStringArray("selected"));
+					List<String> s = Arrays.asList(properties.getStringArray("selected"));
 					for (int i = 0; i < options.length; i++) {
 						checked[i] = s.contains(options[i]);
 						if (checked[i] == true) {
 							resultList[i] = Boolean.TRUE;
 							selectedItems.add(i); // keep info about
-													// preselected items!
+												  // preselected items!
 						}
 					}
 				}
-				getBuilder().setMultiChoiceItems(options, checked,
-						new DialogInterface.OnMultiChoiceClickListener() {
-							// called whenever an item is clicked, toggles
-							// selection info
-							@Override
-							public void onClick(DialogInterface dialog,
-									int which, boolean isChecked) {
-								resultList[which] = isChecked;
-								Log.d(LCAT, resultList.toString());
-								KrollDict kd = new KrollDict();
-								kd.put("index", which);
-								kd.put("checked", isChecked);
-								kd.put("value", isChecked);
-								if (hasListeners("change")) {
-									fireEvent("change", kd);
-								}
-								if (onChange != null)
-									onChange.call(getKrollObject(), kd);
-								if (isChecked) {
-									// we can be sure, item is not already in
-									// selection list
-									selectedItems.add(which);
+				getBuilder()
+					.setMultiChoiceItems(options, checked,
+										 new DialogInterface.OnMultiChoiceClickListener() {
+											 // called whenever an item is clicked, toggles
+											 // selection info
+											 @Override
+											 public void onClick(DialogInterface dialog, int which, boolean isChecked)
+											 {
+												 resultList[which] = isChecked;
+												 Log.d(LCAT, resultList.toString());
+												 KrollDict kd = new KrollDict();
+												 kd.put("index", which);
+												 kd.put("checked", isChecked);
+												 kd.put("value", isChecked);
+												 if (hasListeners("change")) {
+													 fireEvent("change", kd);
+												 }
+												 if (onChange != null)
+													 onChange.call(getKrollObject(), kd);
+												 if (isChecked) {
+													 // we can be sure, item is not already in
+													 // selection list
+													 selectedItems.add(which);
 
-								} else if (selectedItems.contains(which)) {
-									selectedItems.remove(Integer.valueOf(which));
-								}
+												 } else if (selectedItems.contains(which)) {
+													 selectedItems.remove(Integer.valueOf(which));
+												 }
+											 }
+										 })
+
+					// ok returns indexes of selected items and the corresponding
+					// selected items -> wording is not the best
+					.setPositiveButton(okButtonTitle, new DialogInterface.OnClickListener() {
+						@Override
+						public void onClick(DialogInterface dialog, int id)
+						{
+							// convert to int array
+
+							ArrayList<String> selections = new ArrayList<String>();
+							for (Integer s : selectedItems) {
+								selections.add(options[s]);
 							}
-						})
 
-				// ok returns indexes of selected items and the corresponding
-				// selected items -> wording is not the best
-						.setPositiveButton(okButtonTitle,
-								new DialogInterface.OnClickListener() {
-									@Override
-									public void onClick(DialogInterface dialog,
-											int id) {
-										// convert to int array
-
-										ArrayList<String> selections = new ArrayList<String>();
-										for (Integer s : selectedItems) {
-											selections.add(options[s]);
-										}
-
-										KrollDict data = new KrollDict();
-										data.put(
-												"indexes",
-												selectedItems
-														.toArray(new Integer[selectedItems
-																.size()]));
-										data.put("selections", selections
-												.toArray(new String[selections
-														.size()]));
-										data.put("result", resultList);
-										if (hasListeners("click"))
-											fireEvent("click", data);
-									}
-								});
+							KrollDict data = new KrollDict();
+							data.put("indexes", selectedItems.toArray(new Integer[selectedItems.size()]));
+							data.put("selections", selections.toArray(new String[selections.size()]));
+							data.put("result", resultList);
+							if (hasListeners("click"))
+								fireEvent("click", data);
+						}
+					});
 
 				if (cancellable == true) {
 
 					// cancel returns nothing
-					getBuilder().setNegativeButton(cancelButtonTitle,
-							new DialogInterface.OnClickListener() {
-								@Override
-								public void onClick(DialogInterface dialog,
-										int id) {
-									fireEvent("cancel", new KrollDict());
-								}
-							});
+					getBuilder().setNegativeButton(cancelButtonTitle, new DialogInterface.OnClickListener() {
+						@Override
+						public void onClick(DialogInterface dialog, int id)
+						{
+							fireEvent("cancel", new KrollDict());
+						}
+					});
 				} else {
 					getBuilder().setCancelable(false);
 				}
 			}
-
 		}
 
-		public void show() {
+		public void show()
+		{
 			getBuilder().create().show();
 			builder = null;
 			Log.d(LCAT, "show Dialog");
 		}
-
 	}
 
-	public MultiPickerProxy() {
+	public MultiPickerProxy()
+	{
 		super();
 	}
 
 	@Override
-	public TiUIView createView(Activity activity) {
+	public TiUIView createView(Activity activity)
+	{
 		return new MultiPicker(this);
 	}
 
 	@Override
-	public void handleCreationDict(KrollDict options) {
+	public void handleCreationDict(KrollDict options)
+	{
 		super.handleCreationDict(options);
 	}
 
 	@Override
-	protected void handleShow(KrollDict options) {
+	protected void handleShow(KrollDict options)
+	{
 		super.handleShow(options);
 		// If there's a lock on the UI message queue, there's a good chance
 		// we're in the middle of activity stack transitions. An alert
@@ -234,11 +228,11 @@ public class MultiPickerProxy extends TiViewProxy {
 		// AlertDialog.
 		TiUIHelper.runUiDelayedIfBlock(new Runnable() {
 			@Override
-			public void run() {
+			public void run()
+			{
 				MultiPicker d = (MultiPicker) getOrCreateView();
 				d.show();
 			}
 		});
 	}
-
 }

--- a/src/yy/tidialogs/TidialogsModule.java
+++ b/src/yy/tidialogs/TidialogsModule.java
@@ -5,10 +5,10 @@ import org.appcelerator.kroll.annotations.Kroll;
 
 import org.appcelerator.titanium.TiApplication;
 
-@Kroll.module(name="Tidialogs", id="yy.tidialogs")
+@Kroll.module(name = "Tidialogs", id = "yy.tidialogs")
 public class TidialogsModule extends KrollModule
 {
-	
+
 	public TidialogsModule()
 	{
 		super();
@@ -17,7 +17,5 @@ public class TidialogsModule extends KrollModule
 	@Kroll.onAppCreate
 	public static void onAppCreate(TiApplication app)
 	{
-		
 	}
 }
-

--- a/src/yy/tidialogs/TimePickerProxy.java
+++ b/src/yy/tidialogs/TimePickerProxy.java
@@ -17,8 +17,10 @@ import android.text.format.DateFormat;
 import android.widget.TimePicker;
 
 @Kroll.proxy(creatableInModule = TidialogsModule.class)
-public class TimePickerProxy extends TiViewProxy {
-	private class BasicDatePicker extends TiUIView {
+public class TimePickerProxy extends TiViewProxy
+{
+	private class BasicDatePicker extends TiUIView
+	{
 
 		private int hour;
 		private int minute;
@@ -26,57 +28,57 @@ public class TimePickerProxy extends TiViewProxy {
 		private String okButtonTitle;
 		private String cancelButtonTitle;
 
-		public BasicDatePicker(TiViewProxy proxy) {
+		public BasicDatePicker(TiViewProxy proxy)
+		{
 			super(proxy);
-
 		}
 
-		private TimePickerDialog getDialog() {
-			TimePickerDialog picker = new TimePickerDialog(this.proxy.getActivity(),
-						new TimePickerDialog.OnTimeSetListener() {
+		private TimePickerDialog getDialog()
+		{
+			TimePickerDialog picker =
+				new TimePickerDialog(this.proxy.getActivity(), new TimePickerDialog.OnTimeSetListener() {
 
-							@Override
-							public void onTimeSet(TimePicker selectedTime,
-									int selectedHour, int selectedMinute) {
-								// TODO Auto-generated method stub
+					@Override
+					public void onTimeSet(TimePicker selectedTime, int selectedHour, int selectedMinute)
+					{
+						// TODO Auto-generated method stub
 
-								hour = selectedHour;
-								minute = selectedMinute;
+						hour = selectedHour;
+						minute = selectedMinute;
 
-								KrollDict data = new KrollDict();
+						KrollDict data = new KrollDict();
 
-									Calendar calendar = Calendar.getInstance();
-									calendar.set(Calendar.HOUR_OF_DAY, hour);
-									calendar.set(Calendar.MINUTE, minute);
-									Date value = calendar.getTime();
+						Calendar calendar = Calendar.getInstance();
+						calendar.set(Calendar.HOUR_OF_DAY, hour);
+						calendar.set(Calendar.MINUTE, minute);
+						Date value = calendar.getTime();
 
-									data.put("value", value);
-									data.put("hour", hour);
-									data.put("minute", minute);
-                                    fireEvent("click", data);
-
-							}
-						}, hour, minute, DateFormat.is24HourFormat(this.proxy
-								.getActivity()));
+						data.put("value", value);
+						data.put("hour", hour);
+						data.put("minute", minute);
+						fireEvent("click", data);
+					}
+				}, hour, minute, DateFormat.is24HourFormat(this.proxy.getActivity()));
 
 			picker.setCanceledOnTouchOutside(false);
 
 			picker.setButton(DialogInterface.BUTTON_POSITIVE, okButtonTitle, picker);
 
-			picker.setButton(DialogInterface.BUTTON_NEGATIVE, cancelButtonTitle,
-				new DialogInterface.OnClickListener() {
+			picker.setButton(DialogInterface.BUTTON_NEGATIVE, cancelButtonTitle, new DialogInterface.OnClickListener() {
 
-					@Override
-					public void onClick(DialogInterface dialog, int which) {
-						fireEvent("cancel", new KrollDict());
-					}
-				});
+				@Override
+				public void onClick(DialogInterface dialog, int which)
+				{
+					fireEvent("cancel", new KrollDict());
+				}
+			});
 
 			return picker;
 		}
 
 		@Override
-		public void processProperties(KrollDict d) {
+		public void processProperties(KrollDict d)
+		{
 			super.processProperties(d);
 
 			Calendar c = Calendar.getInstance();
@@ -100,7 +102,7 @@ public class TimePickerProxy extends TiViewProxy {
 			if (d.containsKey("okButtonTitle")) {
 				okButtonTitle = d.getString("okButtonTitle");
 			} else {
-				okButtonTitle =  this.proxy.getActivity().getApplication().getResources().getString(R.string.ok);
+				okButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.ok);
 			}
 			if (d.containsKey("cancelButtonTitle")) {
 				cancelButtonTitle = d.getString("cancelButtonTitle");
@@ -109,32 +111,37 @@ public class TimePickerProxy extends TiViewProxy {
 			}
 		}
 
-		public void show() {
+		public void show()
+		{
 			getDialog().show();
 		}
-
 	}
 
-	public TimePickerProxy() {
+	public TimePickerProxy()
+	{
 		super();
 	}
 
 	@Override
-	public TiUIView createView(Activity activity) {
+	public TiUIView createView(Activity activity)
+	{
 		return new BasicDatePicker(this);
 	}
 
 	@Override
-	public void handleCreationDict(KrollDict options) {
+	public void handleCreationDict(KrollDict options)
+	{
 		super.handleCreationDict(options);
 	}
 
 	@Override
-	protected void handleShow(KrollDict options) {
+	protected void handleShow(KrollDict options)
+	{
 		super.handleShow(options);
 		TiUIHelper.runUiDelayedIfBlock(new Runnable() {
 			@Override
-			public void run() {
+			public void run()
+			{
 				BasicDatePicker d = (BasicDatePicker) getOrCreateView();
 				d.show();
 			}

--- a/src/yy/tidialogs/TimePickerProxy.java
+++ b/src/yy/tidialogs/TimePickerProxy.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIView;
 
 import android.R;
@@ -23,6 +24,7 @@ public class TimePickerProxy extends BaseDialogProxy
 
 		private int hour;
 		private int minute;
+		private boolean is24HourView;
 
 		private String okButtonTitle;
 		private String cancelButtonTitle;
@@ -57,7 +59,7 @@ public class TimePickerProxy extends BaseDialogProxy
 						data.put("minute", minute);
 						fireEvent("click", data);
 					}
-				}, hour, minute, DateFormat.is24HourFormat(this.proxy.getActivity()));
+				}, hour, minute, is24HourView);
 
 			picker.setCanceledOnTouchOutside(false);
 
@@ -97,6 +99,12 @@ public class TimePickerProxy extends BaseDialogProxy
 				} else {
 					minute = c.get(Calendar.MINUTE);
 				}
+			}
+
+			if (d.containsKey("format24")) {
+				is24HourView = TiConvert.toBoolean(d, "format24");
+			} else {
+				is24HourView = DateFormat.is24HourFormat(this.proxy.getActivity());
 			}
 
 			if (d.containsKey("okButtonTitle")) {

--- a/src/yy/tidialogs/TimePickerProxy.java
+++ b/src/yy/tidialogs/TimePickerProxy.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.proxy.TiViewProxy;
-import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
 import android.R;
@@ -17,9 +16,9 @@ import android.text.format.DateFormat;
 import android.widget.TimePicker;
 
 @Kroll.proxy(creatableInModule = TidialogsModule.class)
-public class TimePickerProxy extends TiViewProxy
+public class TimePickerProxy extends BaseDialogProxy
 {
-	private class BasicDatePicker extends TiUIView
+	private class BasicDatePicker extends BaseUIDialog
 	{
 
 		private int hour;
@@ -33,7 +32,7 @@ public class TimePickerProxy extends TiViewProxy
 			super(proxy);
 		}
 
-		private TimePickerDialog getDialog()
+		protected TimePickerDialog getDialog()
 		{
 			TimePickerDialog picker =
 				new TimePickerDialog(this.proxy.getActivity(), new TimePickerDialog.OnTimeSetListener() {
@@ -73,6 +72,7 @@ public class TimePickerProxy extends TiViewProxy
 				}
 			});
 
+			dialog = picker;
 			return picker;
 		}
 
@@ -110,11 +110,6 @@ public class TimePickerProxy extends TiViewProxy
 				cancelButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.cancel);
 			}
 		}
-
-		public void show()
-		{
-			getDialog().show();
-		}
 	}
 
 	public TimePickerProxy()
@@ -132,19 +127,5 @@ public class TimePickerProxy extends TiViewProxy
 	public void handleCreationDict(KrollDict options)
 	{
 		super.handleCreationDict(options);
-	}
-
-	@Override
-	protected void handleShow(KrollDict options)
-	{
-		super.handleShow(options);
-		TiUIHelper.runUiDelayedIfBlock(new Runnable() {
-			@Override
-			public void run()
-			{
-				BasicDatePicker d = (BasicDatePicker) getOrCreateView();
-				d.show();
-			}
-		});
 	}
 }

--- a/src/yy/tidialogs/TimePickerProxy.java
+++ b/src/yy/tidialogs/TimePickerProxy.java
@@ -65,14 +65,7 @@ public class TimePickerProxy extends BaseDialogProxy
 
 			picker.setButton(DialogInterface.BUTTON_POSITIVE, okButtonTitle, picker);
 
-			picker.setButton(DialogInterface.BUTTON_NEGATIVE, cancelButtonTitle, new DialogInterface.OnClickListener() {
-
-				@Override
-				public void onClick(DialogInterface dialog, int which)
-				{
-					fireEvent("cancel", new KrollDict());
-				}
-			});
+			picker.setOnDismissListener(dismissListener);
 
 			dialog = picker;
 			return picker;

--- a/src/yy/tidialogs/TimePickerProxy.java
+++ b/src/yy/tidialogs/TimePickerProxy.java
@@ -5,6 +5,7 @@ import java.util.Date;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIView;
@@ -71,11 +72,12 @@ public class TimePickerProxy extends BaseDialogProxy
 			// our TiTimePickerDialog. It was fixed from Android 5.0.
 			TimePickerDialog picker;
 
+			Activity activity = TiApplication.getAppCurrentActivity();
 			if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 				&& (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)) {
-				picker = new TiTimePickerDialog(proxy.getActivity(), timeSetListener, hour, minute, is24HourView);
+				picker = new TiTimePickerDialog(activity, timeSetListener, hour, minute, is24HourView);
 			} else {
-				picker = new TimePickerDialog(proxy.getActivity(), timeSetListener, hour, minute, is24HourView);
+				picker = new TimePickerDialog(activity, timeSetListener, hour, minute, is24HourView);
 			}
 
 			picker.setCanceledOnTouchOutside(false);
@@ -114,18 +116,20 @@ public class TimePickerProxy extends BaseDialogProxy
 			if (d.containsKey("format24")) {
 				is24HourView = TiConvert.toBoolean(d, "format24");
 			} else {
-				is24HourView = DateFormat.is24HourFormat(this.proxy.getActivity());
+				is24HourView = DateFormat.is24HourFormat(TiApplication.getAppCurrentActivity());
 			}
 
 			if (d.containsKey("okButtonTitle")) {
 				okButtonTitle = d.getString("okButtonTitle");
 			} else {
-				okButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.ok);
+				okButtonTitle =
+					TiApplication.getAppCurrentActivity().getApplication().getResources().getString(R.string.ok);
 			}
 			if (d.containsKey("cancelButtonTitle")) {
 				cancelButtonTitle = d.getString("cancelButtonTitle");
 			} else {
-				cancelButtonTitle = this.proxy.getActivity().getApplication().getResources().getString(R.string.cancel);
+				cancelButtonTitle =
+					TiApplication.getAppCurrentActivity().getApplication().getResources().getString(R.string.cancel);
 			}
 		}
 	}

--- a/src/yy/tidialogs/TimePickerProxy.java
+++ b/src/yy/tidialogs/TimePickerProxy.java
@@ -39,6 +39,9 @@ public class TimePickerProxy extends BaseDialogProxy
 
 		protected TimePickerDialog getDialog()
 		{
+			if (dialog != null) {
+				return (TimePickerDialog) dialog;
+			}
 			TimePickerDialog.OnTimeSetListener timeSetListener = new TimePickerDialog.OnTimeSetListener() {
 
 				@Override

--- a/src/yy/tidialogs/TimePickerProxy.java
+++ b/src/yy/tidialogs/TimePickerProxy.java
@@ -14,12 +14,15 @@ import android.app.Activity;
 import android.app.TimePickerDialog;
 import android.content.DialogInterface;
 import android.text.format.DateFormat;
+import android.os.Build;
 import android.widget.TimePicker;
+
+import ti.modules.titanium.ui.widget.picker.TiTimePickerDialog;
 
 @Kroll.proxy(creatableInModule = TidialogsModule.class)
 public class TimePickerProxy extends BaseDialogProxy
 {
-	private class BasicDatePicker extends BaseUIDialog
+	private class BasicTimePicker extends BaseUIDialog
 	{
 
 		private int hour;
@@ -29,37 +32,48 @@ public class TimePickerProxy extends BaseDialogProxy
 		private String okButtonTitle;
 		private String cancelButtonTitle;
 
-		public BasicDatePicker(TiViewProxy proxy)
+		public BasicTimePicker(TiViewProxy proxy)
 		{
 			super(proxy);
 		}
 
 		protected TimePickerDialog getDialog()
 		{
-			TimePickerDialog picker =
-				new TimePickerDialog(this.proxy.getActivity(), new TimePickerDialog.OnTimeSetListener() {
+			TimePickerDialog.OnTimeSetListener timeSetListener = new TimePickerDialog.OnTimeSetListener() {
 
-					@Override
-					public void onTimeSet(TimePicker selectedTime, int selectedHour, int selectedMinute)
-					{
-						// TODO Auto-generated method stub
+				@Override
+				public void onTimeSet(TimePicker selectedTime, int selectedHour, int selectedMinute)
+				{
+					// TODO Auto-generated method stub
 
-						hour = selectedHour;
-						minute = selectedMinute;
+					hour = selectedHour;
+					minute = selectedMinute;
 
-						KrollDict data = new KrollDict();
+					KrollDict data = new KrollDict();
 
-						Calendar calendar = Calendar.getInstance();
-						calendar.set(Calendar.HOUR_OF_DAY, hour);
-						calendar.set(Calendar.MINUTE, minute);
-						Date value = calendar.getTime();
+					Calendar calendar = Calendar.getInstance();
+					calendar.set(Calendar.HOUR_OF_DAY, hour);
+					calendar.set(Calendar.MINUTE, minute);
+					Date value = calendar.getTime();
 
-						data.put("value", value);
-						data.put("hour", hour);
-						data.put("minute", minute);
-						fireEvent("click", data);
-					}
-				}, hour, minute, is24HourView);
+					data.put("value", value);
+					data.put("hour", hour);
+					data.put("minute", minute);
+					fireEvent("click", data);
+				}
+			};
+
+			// TimePickerDialog has a bug in Android 4.x
+			// If build version is using Android 4.x, use
+			// our TiTimePickerDialog. It was fixed from Android 5.0.
+			TimePickerDialog picker;
+
+			if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+				&& (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)) {
+				picker = new TiTimePickerDialog(proxy.getActivity(), timeSetListener, hour, minute, is24HourView);
+			} else {
+				picker = new TimePickerDialog(proxy.getActivity(), timeSetListener, hour, minute, is24HourView);
+			}
 
 			picker.setCanceledOnTouchOutside(false);
 
@@ -121,7 +135,7 @@ public class TimePickerProxy extends BaseDialogProxy
 	@Override
 	public TiUIView createView(Activity activity)
 	{
-		return new BasicDatePicker(this);
+		return new BasicTimePicker(this);
 	}
 
 	@Override


### PR DESCRIPTION
1. added `.clang-format` style file and all sources are formatted using it (this is default style and now it is included in android module template)
2. added classes `BaseUIDialog` and `BaseDialogProxy`. `BaseUIDialog` implements `hide` and `release` methods, so now we can call `hide` on proxy and dialog will be hidden.
3. added missing properties from upsteam: `minDate`, `maxDate`, `format24`.
4. `cancel` event is fired on dialog dismiss (we can catch `back` button)


P.S. Main goal of this changes is to have ability to hide dialog (which is not provided in SDK).